### PR TITLE
Check BugReports as well

### DIFF
--- a/R/get_pkgs_url.R
+++ b/R/get_pkgs_url.R
@@ -4,8 +4,12 @@ GITHUB_PATTERN <- '^https?://github.com'
 get_pkgs_url <- function() {
   pkgs <-
     utils::installed.packages(priority = 'NA',
-                              fields = c('URL', 'GithubRepo', 'GithubUsername'))
-  repos_from_cran <- filter_github_cran(pkgs[, c('URL')])
+                              fields = c('URL', 'BugReports', 'GithubRepo', 'GithubUsername'))
+
+  repos_from_cran_url <- filter_github_cran(pkgs[, c('URL')])
+  repos_from_cran_bugreports <- filter_github_cran(pkgs[, c('BugReports')])
+  repos_from_cran <- union(repos_from_cran_url, repos_from_cran_bugreports)
+
   repos_by_devtools <-
     filter_github_devtool(pkgs[, c('GithubRepo', 'GithubUsername')])
   repos <- union(repos_from_cran, repos_by_devtools)


### PR DESCRIPTION
Hi, thanks for this nice package! ⭐️ 

I found that some packages don't have their GitHub URLs in `URL` field but in `BugReports` field. [animation's Description](https://cran.rstudio.com/web/packages/animation/) is an example. You can find such packages by the following code:

```r
pkgs <- utils::installed.packages(priority = "NA", fields = c("URL", "BugReports"))

has_github_url <- grepl("github.com", pkgs[, "URL"])
has_github_bugreports <- grepl("github.com", pkgs[, "BugReports"])

rownames(pkgs[!has_github_url & has_github_bugreports, ])
#>  [1] "animation"     "anytime"       "arules"       
#>  [4] "arulesViz"     "BH"            "crosstalk"    
#>  [7] "data.table"    "datadogr"      "DBI"          
#> [10] "digest"        "DT"            "formatR"      
#> [13] "htmlTable"     "igraph"        "inline"       
#> [16] "irlba"         "jsonlite"      "knitr"        
#> [19] "leaflet"       "lubridate"     "pkgmaker"     
#> [22] "qap"           "RcppArmadillo" "RcppEigen"    
#> [25] "Rd2roxygen"    "rngtools"      "rstan"        
#> [28] "rtweet"        "selectr"       "seriation"    
#> [31] "shiny"         "shinyjs"       "sourcetools"  
#> [34] "stringi"       "TSP"           "usethis" 
```

This PR is an attempt to catch these packages as well.